### PR TITLE
chore: link to dsp respec rendering

### DIFF
--- a/otterdog/eclipse-dataspace-protocol-base.jsonnet
+++ b/otterdog/eclipse-dataspace-protocol-base.jsonnet
@@ -19,7 +19,7 @@ orgs.newOrg('eclipse-dataspace-protocol-base') {
       gh_pages_build_type: "workflow",
       has_discussions: true,
       has_issues: true,
-      homepage: "https://eclipse.dev/dataspace-protocol-base",
+      homepage: "https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/",
       web_commit_signoff_required: false,
       workflows+: {
         default_workflow_permissions: "write",


### PR DESCRIPTION
the previous link gave a 404, see https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol/issues/34