### PR TITLE
chore: rename best practices

### DIFF
--- a/otterdog/eclipse-dataspace-protocol-base.jsonnet
+++ b/otterdog/eclipse-dataspace-protocol-base.jsonnet
@@ -61,9 +61,10 @@ orgs.newOrg('technology.dataspace-protocol-base', 'eclipse-dataspace-protocol-ba
         },
       ],
     },
-    orgs.newRepo('dsp_best_practices') {
+    orgs.newRepo('BestPractices') {
+      aliases: ['dsp_best_practices'],
       allow_merge_commit: false,
-      allow_rebase_merge: false,
+      allow_rebase_merge: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
       description: "Best Practices in conjunction with the usage and development of the Dataspace Protocol",


### PR DESCRIPTION
## What this PR changes/adds

This PR **renames** the `dsp_best_practices` to `BestPractices`. 

## Why it does that

consistency

## Further notes

This PR was created following
https://otterdog.readthedocs.io/en/latest/userguide/renaming/. As to my knowledge, github will create redirects for HTTP based on the configured alias. Thus no one who has the best practices bookmarked or set as upstream in their IDE will have to change URLs.